### PR TITLE
Update context-expressions.yml

### DIFF
--- a/examples/context-expressions/context-expressions.yml
+++ b/examples/context-expressions/context-expressions.yml
@@ -5,7 +5,7 @@
 name: expressions-example
 on:
   push:
-  pull:
+  pull_request:
 
 jobs:
   use-expressions:
@@ -60,7 +60,7 @@ jobs:
       -
         name: Canceled
         # `canceled()` returns `true` if the workflow was canceled.
-        if: ${{ canceled() }}
+        if: ${{ cancelled() }}
         run: echo "You canceled the workflow"
       -
         name: Failure


### PR DESCRIPTION
- Fix a typo `if: ${{ canceled() }}` to `if: ${{ cancelled() }}`. see [Contexts - GitHub Docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability)

- Fix a trigger It seems the trigger event for pull request in github called `pull_request` rather than `pull`. see [Events that trigger workflows - GitHub Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)